### PR TITLE
Add IRMutations Util

### DIFF
--- a/mlir/include/mlir/IR/IRMapping.h
+++ b/mlir/include/mlir/IR/IRMapping.h
@@ -76,7 +76,11 @@ public:
   }
 
   /// Clears all mappings held by the mapper.
-  void clear() { valueMap.clear(); }
+  void clear() {
+    valueMap.clear();
+    blockMap.clear();
+    operationMap.clear();
+  }
 
   /// Return the held value mapping.
   const DenseMap<Value, Value> &getValueMap() const { return valueMap; }

--- a/mlir/include/mlir/IR/IRMutations.h
+++ b/mlir/include/mlir/IR/IRMutations.h
@@ -142,7 +142,6 @@ class IRMutationManager {
 
   std::string transform_tag;
   mlir::IRMapping ir_mapping;
-  DenseMap<Operation *, Operation *> op_to_op_map;
   DenseMap<Location, Operation *> loc_to_op_map;
   DenseMap<Operation *, Location> op_to_loc_map;
 };

--- a/mlir/include/mlir/IR/IRMutations.h
+++ b/mlir/include/mlir/IR/IRMutations.h
@@ -1,0 +1,131 @@
+#ifndef THIRD_PARTY_LLVM_LLVM_PROJECT_MLIR_INCLUDE_MLIR_IR_IRMUTATIONS_H_
+#define THIRD_PARTY_LLVM_LLVM_PROJECT_MLIR_INCLUDE_MLIR_IR_IRMUTATIONS_H_
+
+#include "mlir/IR/IRMapping.h"
+#include "mlir/IR/Location.h"
+#include "mlir/IR/Operation.h"
+#include "mlir/Support/LLVM.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/raw_ostream.h"
+
+#include <memory>
+
+namespace mlir {
+
+using OpOrValueLocId = std::pair<StringRef, Location>;
+
+class MutationBase {
+ public:
+  MutationBase();
+
+  virtual ~MutationBase() = default;
+
+  MutationBase(std::string transform_tag);
+
+  void addPrevOpId(const OpOrValueLocId &op_or_value_loc_id);
+
+  void addCurOpId(const OpOrValueLocId &op_or_value_loc_id);
+
+  std::vector<OpOrValueLocId> getPrevOpIds();
+
+  std::vector<OpOrValueLocId> getCurOpIds();
+
+  std::string getTransformTag();
+
+  void setTransformTag(std::string transform_tag);
+
+  void print();
+
+ private:
+  virtual void printInternal() = 0;
+
+  std::vector<OpOrValueLocId> prev_op_ids;
+  std::vector<OpOrValueLocId> cur_op_ids;
+  std::string transform_tag;
+};
+
+class FusedMut : public MutationBase {
+ private:
+  void printInternal() override { llvm::outs() << " are fused"; };
+};
+
+class UnFusedMut : public MutationBase {
+ private:
+  void printInternal() override { llvm::outs() << " is un-fused"; };
+};
+
+class InlineMut : public MutationBase {
+ private:
+  void printInternal() override { llvm::outs() << " is inlined"; };
+};
+
+class MoveMut : public MutationBase {
+ private:
+  void printInternal() override { llvm::outs() << " is moved"; };
+};
+
+class DeleteMut : public MutationBase {
+ private:
+  void printInternal() override { llvm::outs() << " is deleted"; };
+};
+
+class IdentityMut : public MutationBase {
+ private:
+  void printInternal() override { llvm::outs() << " remained unmutated"; };
+};
+
+class ConversionMut : public MutationBase {
+ private:
+  void printInternal() override { llvm::outs() << " converted"; };
+};
+
+class MutationFactory {
+ public:
+  static std::unique_ptr<MutationBase>
+  createIdentityMutation(const OpOrValueLocId &op_id);
+
+  static std::unique_ptr<MutationBase>
+  createDeleteMutation(const OpOrValueLocId &op_id);
+
+  static std::unique_ptr<MutationBase>
+  createMoveMutation(StringRef op_name, Location from, Location to);
+
+  static std::unique_ptr<MutationBase>
+  createInlineMutation(StringRef op_name, Location callee, Location caller);
+
+  static std::unique_ptr<MutationBase>
+  createConversionMutation(StringRef op_name_from, StringRef op_name_to,
+                           Location loc);
+
+  static std::unique_ptr<MutationBase>
+  createUnFusedMutation(const OpOrValueLocId &op_id_from,
+                        const OpOrValueLocId &op_id_to);
+
+  static std::unique_ptr<MutationBase>
+  createFusedMutation(const std::vector<OpOrValueLocId> &fused_from,
+                      const OpOrValueLocId &fused_to);
+};
+
+class IRMutationManager {
+ public:
+  IRMutationManager() = default;
+  void reset(Operation *op_previous, const std::string& transform_tag);
+
+  ~IRMutationManager();
+
+  std::vector<std::unique_ptr<MutationBase>>
+  getMutations(Operation *op_current);
+
+ private:
+  void clear();
+
+  std::string transform_tag;
+  mlir::IRMapping ir_mapping;
+  DenseMap<Operation *, Operation *> op_to_op_map;
+  DenseMap<Location, Operation *> loc_to_op_map;
+  DenseMap<Operation *, Location> op_to_loc_map;
+};
+
+} // namespace mlir
+
+#endif // THIRD_PARTY_LLVM_LLVM_PROJECT_MLIR_INCLUDE_MLIR_IR_IRMUTATIONS_H_

--- a/mlir/include/mlir/IR/IRMutations.h
+++ b/mlir/include/mlir/IR/IRMutations.h
@@ -1,3 +1,16 @@
+//===- IRMutations.h - IR Mutations Utilities ---------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This header file several utility methods for snapshotting the current IR to
+// produce new debug locations.
+//
+//===----------------------------------------------------------------------===//
+
 #ifndef THIRD_PARTY_LLVM_LLVM_PROJECT_MLIR_INCLUDE_MLIR_IR_IRMUTATIONS_H_
 #define THIRD_PARTY_LLVM_LLVM_PROJECT_MLIR_INCLUDE_MLIR_IR_IRMUTATIONS_H_
 
@@ -14,6 +27,11 @@ namespace mlir {
 
 using OpOrValueLocId = std::pair<StringRef, Location>;
 
+/// Base class to hold a single mutation object. This can be extended by
+/// different classes to represent specific mnutation types and hold any
+/// mutation specific information or metedata. For example- In a mutation object
+/// to used to record OpArgMutation, it may be useful to know index of the
+/// mutated openrand.
 class MutationBase {
  public:
   MutationBase();
@@ -79,6 +97,7 @@ class ConversionMut : public MutationBase {
   void printInternal() override { llvm::outs() << " converted"; };
 };
 
+/// Utility class to create the specific Mutation objects
 class MutationFactory {
  public:
   static std::unique_ptr<MutationBase>
@@ -106,6 +125,8 @@ class MutationFactory {
                       const OpOrValueLocId &fused_to);
 };
 
+/// Utility class that can be used to get the list of MutationBase objects after
+/// a pass, pipeline or a rewrite
 class IRMutationManager {
  public:
   IRMutationManager() = default;

--- a/mlir/include/mlir/Transforms/LocationSnapshot.h
+++ b/mlir/include/mlir/Transforms/LocationSnapshot.h
@@ -14,6 +14,7 @@
 #ifndef MLIR_TRANSFORMS_LOCATIONSNAPSHOT_H
 #define MLIR_TRANSFORMS_LOCATIONSNAPSHOT_H
 
+#include "mlir/IR/IRMutations.h"
 #include "mlir/Support/LLVM.h"
 #include "llvm/ADT/StringRef.h"
 

--- a/mlir/lib/IR/CMakeLists.txt
+++ b/mlir/lib/IR/CMakeLists.txt
@@ -20,6 +20,7 @@ add_mlir_library(MLIRIR
   FunctionImplementation.cpp
   FunctionInterfaces.cpp
   IntegerSet.cpp
+  IRMutations.cpp
   Location.cpp
   MLIRContext.cpp
   Operation.cpp

--- a/mlir/lib/IR/IRMutations.cpp
+++ b/mlir/lib/IR/IRMutations.cpp
@@ -165,7 +165,7 @@ IRMutationManager::getMutations(Operation *op_current) {
       // evaluate these mutations as we have access to versions of Op/Module
       // before and after the transform and we should be able to apply
       // equivalance comparisions like this easily-
-      // https://source.corp.google.com/piper///depot/google3/third_party/llvm/llvm-project/mlir/lib/IR/OperationSupport.cpp;l=704-783
+      // llvm-project/mlir/lib/IR/OperationSupport.cpp;l=704-783
       // OperationEquivalence::isEquivalentTo
 
       // 1.1. Check if arguments are mutated

--- a/mlir/lib/IR/IRMutations.cpp
+++ b/mlir/lib/IR/IRMutations.cpp
@@ -1,0 +1,272 @@
+
+#include "mlir/IR/IRMutations.h"
+
+using namespace mlir;
+
+//===----------------------------------------------------------------------===//
+/// MutationBase
+//===----------------------------------------------------------------------===//
+MutationBase::MutationBase() { transform_tag = ""; }
+
+MutationBase::MutationBase(std::string transform_tag)
+    : transform_tag(transform_tag) {
+  prev_op_ids.clear();
+  cur_op_ids.clear();
+}
+
+void MutationBase::addPrevOpId(const OpOrValueLocId &op_or_value_loc_id) {
+  prev_op_ids.push_back(op_or_value_loc_id);
+}
+
+void MutationBase::addCurOpId(const OpOrValueLocId &op_or_value_loc_id) {
+  cur_op_ids.push_back(op_or_value_loc_id);
+}
+
+std::vector<OpOrValueLocId> MutationBase::getPrevOpIds() { return prev_op_ids; }
+
+std::vector<OpOrValueLocId> MutationBase::getCurOpIds() { return cur_op_ids; }
+
+std::string MutationBase::getTransformTag() { return transform_tag; }
+
+void MutationBase::setTransformTag(std::string transform_tag) {
+  this->transform_tag = transform_tag;
+}
+
+void MutationBase::print() {
+  for (size_t i = 0; i < prev_op_ids.size(); i++) {
+    if (i > 0 && i == prev_op_ids.size() - 1) {
+      llvm::outs() << " and ";
+    } else if (i > 0) {
+      llvm::outs() << " , ";
+    }
+    llvm::outs() << prev_op_ids[i].first << " at " << prev_op_ids[i].second;
+  }
+
+  if (!prev_op_ids.empty()) {
+    printInternal();
+  } else {
+    llvm::outs() << "\n\n";
+  }
+
+  for (size_t i = 0; i < cur_op_ids.size(); i++) {
+    llvm::outs() << " to form ";
+
+    if (i > 0 && i == cur_op_ids.size() - 1) {
+      llvm::outs() << " and ";
+    } else if (i > 0) {
+      llvm::outs() << " , ";
+    }
+    llvm::outs() << cur_op_ids[i].first << " at " << cur_op_ids[i].second;
+  }
+  llvm::outs() << "\n\n";
+}
+
+//===----------------------------------------------------------------------===//
+/// MutationFactory
+//===----------------------------------------------------------------------===//
+std::unique_ptr<MutationBase>
+MutationFactory::createIdentityMutation(const OpOrValueLocId &op_id) {
+  std::unique_ptr<MutationBase> mutation(new IdentityMut);
+  mutation->addPrevOpId(op_id);
+  return mutation;
+}
+
+std::unique_ptr<MutationBase>
+MutationFactory::createDeleteMutation(const OpOrValueLocId &op_id) {
+  std::unique_ptr<MutationBase> mutation(new DeleteMut);
+  mutation->addPrevOpId(op_id);
+  return mutation;
+}
+
+std::unique_ptr<MutationBase>
+MutationFactory::createMoveMutation(StringRef op_name, Location from,
+                                    Location to) {
+  std::unique_ptr<MutationBase> mutation(new MoveMut);
+  mutation->addPrevOpId(std::make_pair(op_name, from));
+  mutation->addCurOpId(std::make_pair(op_name, to));
+  return mutation;
+}
+
+std::unique_ptr<MutationBase>
+MutationFactory::createInlineMutation(StringRef op_name, Location callee,
+                                      Location caller) {
+  std::unique_ptr<MutationBase> mutation(new InlineMut);
+  mutation->addPrevOpId(std::make_pair(op_name, callee));
+  mutation->addCurOpId(std::make_pair(op_name, caller));
+  return mutation;
+}
+
+std::unique_ptr<MutationBase>
+MutationFactory::createConversionMutation(StringRef op_name_from,
+                                          StringRef op_name_to, Location loc) {
+  std::unique_ptr<MutationBase> mutation(new ConversionMut);
+  mutation->addPrevOpId(std::make_pair(op_name_from, loc));
+  mutation->addCurOpId(std::make_pair(op_name_to, loc));
+  return mutation;
+}
+
+std::unique_ptr<MutationBase>
+MutationFactory::createUnFusedMutation(const OpOrValueLocId &op_id_from,
+                                       const OpOrValueLocId &op_id_to) {
+  std::unique_ptr<MutationBase> mutation(new UnFusedMut);
+  mutation->addPrevOpId(op_id_from);
+  mutation->addCurOpId(op_id_to);
+  return mutation;
+}
+
+std::unique_ptr<MutationBase> MutationFactory::createFusedMutation(
+    const std::vector<OpOrValueLocId> &fused_from,
+    const OpOrValueLocId &fused_to) {
+  std::unique_ptr<MutationBase> mutation(new FusedMut);
+  for (auto &&op_id : fused_from) {
+    mutation->addPrevOpId(op_id);
+  }
+  mutation->addCurOpId(fused_to);
+  return mutation;
+}
+
+//===----------------------------------------------------------------------===//
+/// IRMutationManager
+//===----------------------------------------------------------------------===//
+void IRMutationManager::reset(Operation *op_previous, const std::string &tag) {
+  clear();
+  op_previous->clone(ir_mapping);
+  op_to_op_map = ir_mapping.getOperationMap();
+  // Map the locations to Ops from the original version of the
+  // module. The locations in this module are guaranteed to be unique as they
+  // are re-numbered just befor this function call.
+  for (auto &&op_pair : op_to_op_map) {
+    loc_to_op_map.insert({op_pair.second->getLoc(), op_pair.second});
+    op_to_loc_map.insert({op_pair.second, op_pair.second->getLoc()});
+  }
+}
+
+IRMutationManager::~IRMutationManager() { clear(); }
+
+std::vector<std::unique_ptr<MutationBase>>
+IRMutationManager::getMutations(Operation *op_current) {
+  llvm::outs() << "Printing IR Mutations occured in- " << transform_tag << "\n";
+  // Create a map of locations to ops for the newly added Op in the
+  // module. The locations in this module are need not be unique as there
+  // could have beed some module transformations
+  DenseMap<Location, std::vector<Operation *>> loc_to_op_map_after;
+  std::vector<Operation *> newly_inserted_ops;
+  std::vector<Operation *> old_mutated_ops;
+
+  std::vector<std::unique_ptr<MutationBase>> mutations;
+
+  op_current->walk([&](Operation *opIt) {
+    // If an op exists BEFORE and AFTER, it can still have mutaions, like
+    // arguments and resulsts
+    if (Operation *op = ir_mapping.lookupOrNull(opIt)) {
+      bool is_op_mutated = false;
+      // The information related to 1.1 and 1.2 is not available directly from
+      // the Source-Location information. However, we should be able to
+      // evaluate these mutations as we have access to versions of Op/Module
+      // before and after the transform and we should be able to apply
+      // equivalance comparisions like this easily-
+      // https://source.corp.google.com/piper///depot/google3/third_party/llvm/llvm-project/mlir/lib/IR/OperationSupport.cpp;l=704-783
+      // OperationEquivalence::isEquivalentTo
+
+      // 1.1. Check if arguments are mutated
+
+      // 1.2. Check if Op result is mutated
+
+      // 1.3. Check if Locations match
+      if (!is_op_mutated && op->getLoc() == opIt->getLoc()) {
+        mutations.push_back(MutationFactory::createIdentityMutation(
+            std::make_pair(op->getName().getStringRef(), op->getLoc())));
+      }
+      // 1.4. Check if Locations do not match. If the locations do not match,
+      // it means the op has been moved
+      if (!is_op_mutated && op->getLoc() != opIt->getLoc()) {
+        mutations.push_back(MutationFactory::createMoveMutation(
+            op->getName().getStringRef(), op->getLoc(), opIt->getLoc()));
+      }
+      // If the Op is present BEFORE and AFTER, delete it from the
+      // loc_to_op_map_before and op_to_loc_map maps, as these maps
+      // will be used to track the deleted Ops and other kinds of mutations
+      op_to_loc_map.erase(op);
+    } else {
+      if (loc_to_op_map_after.find(opIt->getLoc()) ==
+          loc_to_op_map_after.end()) {
+        loc_to_op_map_after.insert({opIt->getLoc(), {}});
+      }
+
+      loc_to_op_map_after[opIt->getLoc()].push_back(opIt);
+      newly_inserted_ops.push_back(opIt);
+    }
+  });
+
+  for (Operation *opIt : newly_inserted_ops) {
+    // If the Op didn't exist BEFORE and exists AFTER the transform, it is
+    // probably newly introduce but still may have been derived from an Op in
+    // BEFORE.
+    if (loc_to_op_map_after[opIt->getLoc()].size() > 1 &&
+        loc_to_op_map.find(opIt->getLoc()) != loc_to_op_map.end()) {
+      Operation *op = loc_to_op_map[opIt->getLoc()];
+      // 2.1. If more than one Op in AFTER have the same location as an Op
+      // in BEFORE, its probably an outcome of an unroll action.
+      mutations.push_back(MutationFactory::createUnFusedMutation(
+          std::make_pair(op->getName().getStringRef(), op->getLoc()),
+          std::make_pair(opIt->getName().getStringRef(), opIt->getLoc())));
+      old_mutated_ops.push_back(op);
+    } else if (loc_to_op_map.find(opIt->getLoc()) != loc_to_op_map.end()) {
+      // 2.2. Check if the Op in AFTER has the same location as an Op in
+      // BEFORE. Its probably a result of 1->1 conversion pattern. Ex. TF ->
+      // TFL Delete the converted Op from the loc_to_op_map and
+      // op_to_loc_map maps
+      Operation *op = loc_to_op_map[opIt->getLoc()];
+      mutations.push_back(MutationFactory::createConversionMutation(
+          op->getName().getStringRef(), opIt->getName().getStringRef(),
+          opIt->getLoc()));
+      old_mutated_ops.push_back(op);
+    } else if (auto fused_loc = opIt->getLoc().dyn_cast<FusedLoc>()) {
+      // 2.3. Check if the Op in AFTER is a result of fusion. Get the list of
+      // fused locations in BEFORE. Delete the fused Ops from the
+      // loc_to_op_map and op_to_loc_map maps
+      std::vector<OpOrValueLocId> op_ids;
+      for (size_t loc_idx = 0; loc_idx < fused_loc.getLocations().size();
+           ++loc_idx) {
+        Operation *op = loc_to_op_map[fused_loc.getLocations()[loc_idx]];
+        op_ids.push_back(
+            std::make_pair(op->getName().getStringRef(), op->getLoc()));
+        old_mutated_ops.push_back(op);
+      }
+      mutations.push_back(MutationFactory::createFusedMutation(
+          op_ids,
+          std::make_pair(opIt->getName().getStringRef(), opIt->getLoc())));
+
+    } else if (auto callsite_loc = opIt->getLoc().dyn_cast<CallSiteLoc>()) {
+      // 2.3. Check if the Op in AFTER is a result of inlining. Get the
+      // original inlined location in BEFORE. Delete the fused Ops from the
+      // loc_to_op_map and op_to_loc_map maps
+      Operation *op = loc_to_op_map[callsite_loc.getCallee()];
+      mutations.push_back(MutationFactory::createInlineMutation(
+          opIt->getName().getStringRef(), callsite_loc.getCallee(),
+          callsite_loc.getCaller()));
+      old_mutated_ops.push_back(op);
+    }
+    for (Operation *m_op : old_mutated_ops) {
+      op_to_loc_map.erase(m_op);
+    }
+  }
+
+  if (!op_to_loc_map.empty()) {
+    // There are some Ops BEFORE that have not been accounted for in AFTER,
+    // consider them deleted?
+    for (auto deleted_op_loc_pair : op_to_loc_map) {
+      Operation *deleted_op = deleted_op_loc_pair.first;
+      mutations.push_back(MutationFactory::createDeleteMutation(std::make_pair(
+          deleted_op->getName().getStringRef(), deleted_op->getLoc())));
+    }
+  }
+  return mutations;
+}
+
+void IRMutationManager::clear() {
+  ir_mapping.clear();
+  op_to_op_map.clear();
+  loc_to_op_map.clear();
+  op_to_loc_map.clear();
+}

--- a/mlir/lib/IR/IRMutations.cpp
+++ b/mlir/lib/IR/IRMutations.cpp
@@ -128,17 +128,16 @@ std::unique_ptr<MutationBase> MutationFactory::createFusedMutation(
 //===----------------------------------------------------------------------===//
 /// IRMutationManager
 //===----------------------------------------------------------------------===//
-void IRMutationManager::reset(Operation *op_previous, const std::string &tag) {
+void IRMutationManager::reset(Operation *op, const std::string &tag) {
   clear();
-  op_previous->clone(ir_mapping);
-  op_to_op_map = ir_mapping.getOperationMap();
+  Operation *op_previous = op->clone(ir_mapping);
   // Map the locations to Ops from the original version of the
   // module. The locations in this module are guaranteed to be unique as they
   // are re-numbered just befor this function call.
-  for (auto &&op_pair : op_to_op_map) {
-    loc_to_op_map.insert({op_pair.second->getLoc(), op_pair.second});
-    op_to_loc_map.insert({op_pair.second, op_pair.second->getLoc()});
-  }
+  op_previous->walk([&](Operation *opIt) {
+    loc_to_op_map.insert({opIt->getLoc(), opIt});
+    op_to_loc_map.insert({opIt, opIt->getLoc()});
+  });
 }
 
 IRMutationManager::~IRMutationManager() { clear(); }
@@ -266,7 +265,6 @@ IRMutationManager::getMutations(Operation *op_current) {
 
 void IRMutationManager::clear() {
   ir_mapping.clear();
-  op_to_op_map.clear();
   loc_to_op_map.clear();
   op_to_loc_map.clear();
 }

--- a/mlir/lib/Transforms/LocationSnapshot.cpp
+++ b/mlir/lib/Transforms/LocationSnapshot.cpp
@@ -140,12 +140,25 @@ struct LocationSnapshotPass
 
   void runOnOperation() override {
     Operation *op = getOperation();
-    if (failed(generateLocationsFromIR(fileName, op, OpPrintingFlags(), tag)))
-      return signalPassFailure();
+    auto mutations_list = getMutationManager().getMutations(op);
+    for (auto &&it : mutations_list) {
+      it->print();
+    }
+
+    if (!mutations_list.empty()) {
+      if (failed(generateLocationsFromIR(fileName, op, OpPrintingFlags(), tag)))
+        return signalPassFailure();
+    }
+
+    getMutationManager().reset(op, std::string{});
   }
 
   /// The printing flags to use when creating the snapshot.
   OpPrintingFlags flags;
+  static IRMutationManager& getMutationManager(){
+    static IRMutationManager mutations;
+    return mutations;
+  };
 };
 } // namespace
 


### PR DESCRIPTION
**Objective:**
To gather LLVM/MLIR community feedback on a simple approach (tool/utility), using MLIR Source Locations and LocationSnapshot, to derive a list of mutations/changes occurred to an MLIR entity(Op, Region, Block)  after single Pass, a pass-pipeline or even after a PatternRewriter rewrite.

**Introduction:**
Debugging errors or unexpected behavior in MLIR Passes can be time consuming and un-intuitive. To enable users to debug these issues during execution of any compiler pipeline, it is important to preserve the transformation details and make them accessible/usable to the users(or any tool that can help with easy consumption of the details) . The fundamental problem that can be solved with preserving the transformation information is op provenance. In other words, users can benefit from being able to trace an op in a given dialect or pass, back to where it was in each transformation pass within the compiler pipeline, and back to its source. 

Consider the following input MLIR Module-
_input.mlir_
```cpp
module {
func.func @func_with_tf_add_op(%arg0 : tensor<128x1xf32>) -> tensor<128x1xf32> {
  %cst = "tf.Const"() {value = dense<2.0> : tensor<1xf32>} : () -> tensor<1xf32> 
  %4 = "tf.AddV2"(%arg0, %cst) : (tensor<128x1xf32>, tensor<1xf32>) -> tensor<128x1xf32> 
  %5 = "tf.Identity"(%4) : (tensor<128x1xf32>) -> tensor<128x1xf32> 
  func.return %5: tensor<128x1xf32>
}

func.func @batchmatmul2fullyconnected(%arg0: tensor<128x2xf32>, %arg1: tensor<256xf32>) -> (tensor<128x1xf32>) {
  %cst_0 = "tf.Const"() {value = dense<[[1.0], [2.0]]> : tensor<2x1xf32>} : () -> tensor<2x1xf32> 
  %cst_1 = "tf.Const"() {value = dense<[128, 2]> : tensor<2xi32>} : () -> tensor<2xi32> 
  %0 = "tf.Shape"(%arg0) : (tensor<128x2xf32>) -> tensor<2xi32> 
  %1 = "tf.Reshape"(%arg1, %0) : (tensor<256xf32>, tensor<2xi32>) -> tensor<128x2xf32> 
  %2 = "tf.EnsureShape"(%1) {shape = #tf_type.shape<128x2>} : (tensor<128x2xf32>) -> tensor<128x2xf32> 
  %3 = "tf.BatchMatMul"(%2, %cst_0) : (tensor<128x2xf32>, tensor<2x1xf32>) -> tensor<128x1xf32> 
  %4 = func.call @func_with_tf_add_op(%3) : (tensor<128x1xf32>) -> tensor<128x1xf32>
  func.return %4 : tensor<128x1xf32> 
}
}
```

Running the `tf-opt` tool to apply `-inline='default-pipeline='''`, `-tf-shape-inference` , `-tfl-prepare-tf`, `-tfl-legalize-tf` and `-tfl-optimize` Passes(in that order) will produce the following output-

```cpp
module {
  func.func @func_with_tf_add_op(%arg0: tensor<128x1xf32>) -> tensor<128x1xf32> {
    %cst = arith.constant dense<2.000000e+00> : tensor<1xf32>
    %0 = tfl.add(%arg0, %cst) {fused_activation_function = "NONE"} : (tensor<128x1xf32>, tensor<1xf32>) -> tensor<128x1xf32>
    return %0 : tensor<128x1xf32>
  }
  func.func @batchmatmul2fullyconnected(%arg0: tensor<128x2xf32>, %arg1: tensor<256xf32>) -> tensor<128x1xf32> {
    %0 = "tfl.pseudo_const"() {value = dense<[[1.000000e+00, 2.000000e+00]]> : tensor<1x2xf32>} : () -> tensor<*xf32>
    %cst = arith.constant dense<[128, 2]> : tensor<2xi32>
    %cst_0 = arith.constant dense<2.000000e+00> : tensor<1xf32>
    %1 = "tfl.reshape"(%arg1, %cst) : (tensor<256xf32>, tensor<2xi32>) -> tensor<128x2xf32>
    %2 = "tfl.fully_connected"(%1, %0, %cst_0) {fused_activation_function = "NONE", keep_num_dims = false, weights_format = "DEFAULT"} : (tensor<128x2xf32>, tensor<*xf32>, tensor<1xf32>) -> tensor<128x1xf32>
    return %2 : tensor<128x1xf32>
  }
}
```
The input MLIR Module underwent a series of modifications as part of each of the above mentioned passes. It is possible, that one or more of the applied MLIR Passes may have made undesirable changes. One way to debug such issue is by printing the MLIR text to the terminal with the help of the available MLIR Tooling, like `--mlir-print-ir-after-all` and `--mlir-print-debuginfo`.

For example, this is what is printed to the terminal with the `--mlir-print-ir-after-all` option set-
```cpp
// -----// IR Dump After Inliner (inline) //----- //
module {
  func.func @func_with_tf_add_op(%arg0: tensor<128x1xf32>) -> tensor<128x1xf32> {
    %cst = "tf.Const"() {value = dense<2.000000e+00> : tensor<1xf32>} : () -> tensor<1xf32>
    %0 = "tf.AddV2"(%arg0, %cst) : (tensor<128x1xf32>, tensor<1xf32>) -> tensor<128x1xf32>
    %1 = "tf.Identity"(%0) : (tensor<128x1xf32>) -> tensor<128x1xf32>
    return %1 : tensor<128x1xf32>
  }
  func.func @batchmatmul2fullyconnected(%arg0: tensor<128x2xf32>, %arg1: tensor<256xf32>) -> tensor<128x1xf32> {
    %cst = "tf.Const"() {value = dense<[[1.000000e+00], [2.000000e+00]]> : tensor<2x1xf32>} : () -> tensor<2x1xf32>
    %cst_0 = "tf.Const"() {value = dense<[128, 2]> : tensor<2xi32>} : () -> tensor<2xi32>
    %0 = "tf.Shape"(%arg0) : (tensor<128x2xf32>) -> tensor<2xi32>
    %1 = "tf.Reshape"(%arg1, %0) : (tensor<256xf32>, tensor<2xi32>) -> tensor<128x2xf32>
    %2 = "tf.EnsureShape"(%1) {shape = #tf_type.shape<128x2>} : (tensor<128x2xf32>) -> tensor<128x2xf32>
    %3 = "tf.BatchMatMul"(%2, %cst) : (tensor<128x2xf32>, tensor<2x1xf32>) -> tensor<128x1xf32>
    %cst_1 = "tf.Const"() {value = dense<2.000000e+00> : tensor<1xf32>} : () -> tensor<1xf32>
    %4 = "tf.AddV2"(%3, %cst_1) : (tensor<128x1xf32>, tensor<1xf32>) -> tensor<128x1xf32>
    %5 = "tf.Identity"(%4) : (tensor<128x1xf32>) -> tensor<128x1xf32>
    return %5 : tensor<128x1xf32>
  }
}


// -----// IR Dump After TensorFlowShapeInferencePass (tf-shape-inference) //----- //
module {
  func.func @func_with_tf_add_op(%arg0: tensor<128x1xf32>) -> tensor<128x1xf32> {
    %cst = "tf.Const"() {value = dense<2.000000e+00> : tensor<1xf32>} : () -> tensor<1xf32>
    %0 = "tf.AddV2"(%arg0, %cst) : (tensor<128x1xf32>, tensor<1xf32>) -> tensor<128x1xf32>
    %1 = "tf.Identity"(%0) : (tensor<128x1xf32>) -> tensor<128x1xf32>
    return %1 : tensor<128x1xf32>
  }
  func.func @batchmatmul2fullyconnected(%arg0: tensor<128x2xf32>, %arg1: tensor<256xf32>) -> tensor<128x1xf32> {
    %cst = "tf.Const"() {value = dense<[[1.000000e+00], [2.000000e+00]]> : tensor<2x1xf32>} : () -> tensor<2x1xf32>
    %cst_0 = "tf.Const"() {value = dense<[128, 2]> : tensor<2xi32>} : () -> tensor<2xi32>
    %0 = "tf.Shape"(%arg0) : (tensor<128x2xf32>) -> tensor<2xi32>
    %1 = "tf.Reshape"(%arg1, %0) : (tensor<256xf32>, tensor<2xi32>) -> tensor<128x2xf32>
    %2 = "tf.EnsureShape"(%1) {shape = #tf_type.shape<128x2>} : (tensor<128x2xf32>) -> tensor<128x2xf32>
    %3 = "tf.BatchMatMul"(%2, %cst) : (tensor<128x2xf32>, tensor<2x1xf32>) -> tensor<128x1xf32>
    %cst_1 = "tf.Const"() {value = dense<2.000000e+00> : tensor<1xf32>} : () -> tensor<1xf32>
    %4 = "tf.AddV2"(%3, %cst_1) : (tensor<128x1xf32>, tensor<1xf32>) -> tensor<128x1xf32>
    %5 = "tf.Identity"(%4) : (tensor<128x1xf32>) -> tensor<128x1xf32>
    return %5 : tensor<128x1xf32>
  }
}


// -----// IR Dump After PrepareTFPass (tfl-prepare-tf) //----- //
func.func @func_with_tf_add_op(%arg0: tensor<128x1xf32>) -> tensor<128x1xf32> {
  %cst = arith.constant dense<2.000000e+00> : tensor<1xf32>
  %0 = "tf.AddV2"(%arg0, %cst) : (tensor<128x1xf32>, tensor<1xf32>) -> tensor<128x1xf32>
  return %0 : tensor<128x1xf32>
}

// -----// IR Dump After LegalizeTFPass (tfl-legalize-tf) //----- //
func.func @func_with_tf_add_op(%arg0: tensor<128x1xf32>) -> tensor<128x1xf32> {
  %cst = arith.constant dense<2.000000e+00> : tensor<1xf32>
  %0 = tfl.add(%arg0, %cst) {fused_activation_function = "NONE"} : (tensor<128x1xf32>, tensor<1xf32>) -> tensor<128x1xf32>
  return %0 : tensor<128x1xf32>
}

// -----// IR Dump After OptimizePass (tfl-optimize) //----- //
func.func @func_with_tf_add_op(%arg0: tensor<128x1xf32>) -> tensor<128x1xf32> {
  %cst = arith.constant dense<2.000000e+00> : tensor<1xf32>
  %0 = tfl.add(%arg0, %cst) {fused_activation_function = "NONE"} : (tensor<128x1xf32>, tensor<1xf32>) -> tensor<128x1xf32>
  return %0 : tensor<128x1xf32>
}

// -----// IR Dump After PrepareTFPass (tfl-prepare-tf) //----- //
func.func @batchmatmul2fullyconnected(%arg0: tensor<128x2xf32>, %arg1: tensor<256xf32>) -> tensor<128x1xf32> {
  %cst = "tf.Const"() {value = dense<[[1.000000e+00, 2.000000e+00]]> : tensor<1x2xf32>} : () -> tensor<*xf32>
  %cst_0 = arith.constant dense<[128, 2]> : tensor<2xi32>
  %cst_1 = arith.constant dense<2.000000e+00> : tensor<1xf32>
  %0 = "tf.Reshape"(%arg1, %cst_0) : (tensor<256xf32>, tensor<2xi32>) -> tensor<128x2xf32>
  %1 = "tf.MatMul"(%0, %cst) {transpose_a = false, transpose_b = true} : (tensor<128x2xf32>, tensor<*xf32>) -> tensor<128x1xf32>
  %2 = "tf.AddV2"(%1, %cst_1) : (tensor<128x1xf32>, tensor<1xf32>) -> tensor<128x1xf32>
  return %2 : tensor<128x1xf32>
}

// -----// IR Dump After LegalizeTFPass (tfl-legalize-tf) //----- //
func.func @batchmatmul2fullyconnected(%arg0: tensor<128x2xf32>, %arg1: tensor<256xf32>) -> tensor<128x1xf32> {
  %0 = "tfl.pseudo_const"() {value = dense<[[1.000000e+00, 2.000000e+00]]> : tensor<1x2xf32>} : () -> tensor<*xf32>
  %cst = arith.constant dense<[128, 2]> : tensor<2xi32>
  %cst_0 = arith.constant dense<2.000000e+00> : tensor<1xf32>
  %1 = "tfl.reshape"(%arg1, %cst) : (tensor<256xf32>, tensor<2xi32>) -> tensor<128x2xf32>
  %2 = "tfl.no_value"() {value} : () -> none
  %3 = "tfl.fully_connected"(%1, %0, %2) {fused_activation_function = "NONE", keep_num_dims = false, weights_format = "DEFAULT"} : (tensor<128x2xf32>, tensor<*xf32>, none) -> tensor<128x1xf32>
  %4 = tfl.add(%3, %cst_0) {fused_activation_function = "NONE"} : (tensor<128x1xf32>, tensor<1xf32>) -> tensor<128x1xf32>
  return %4 : tensor<128x1xf32>
}

// -----// IR Dump After OptimizePass (tfl-optimize) //----- //
func.func @batchmatmul2fullyconnected(%arg0: tensor<128x2xf32>, %arg1: tensor<256xf32>) -> tensor<128x1xf32> {
  %0 = "tfl.pseudo_const"() {value = dense<[[1.000000e+00, 2.000000e+00]]> : tensor<1x2xf32>} : () -> tensor<*xf32>
  %cst = arith.constant dense<[128, 2]> : tensor<2xi32>
  %cst_0 = arith.constant dense<2.000000e+00> : tensor<1xf32>
  %1 = "tfl.reshape"(%arg1, %cst) : (tensor<256xf32>, tensor<2xi32>) -> tensor<128x2xf32>
  %2 = "tfl.fully_connected"(%1, %0, %cst_0) {fused_activation_function = "NONE", keep_num_dims = false, weights_format = "DEFAULT"} : (tensor<128x2xf32>, tensor<*xf32>, tensor<1xf32>) -> tensor<128x1xf32>
  return %2 : tensor<128x1xf32>
}
```

While its possible to debug issues by manually inspecting the MLIR dumps, it would be better to know exactly what happened in a given Pass or a PatternRewriter, especially as the MLIR dumps are usually very large.

**Use-case:**
1. Print a list of mutations after every pass or selected passes; print mutations made to a given Op, with the help of MLIR cli options like- `--mlir-print-ir-mutations-after-all`, `--mlir-print-ir-mutations-after=<pass1, pass2>` or `--mlir-print-op-mutations=<Op1, Op2>`, etc.

>   tf.BatchMatMul is `transformed` to tf.MatMul as a result of `-tfl-prepare-tf` pass.
> 
>   tf.MatMul is `unfused` to form tfl.no_value and tfl.fully_connected as a result of `-tfl-legalize-tf` pass.
> 
>   tfl.no_value, tfl.fully_connected and tfl.add `fused` to form tfl.fully_connectd as a result of `-tfl-optimize` pass.


2.  Display mutations as MLIR-Diff

![image](https://user-images.githubusercontent.com/110555921/221374207-c6a6832d-167b-438b-a919-3f4477890921.png)

3. Or pure graphical visualization purpose for Op traceability

**Tool Interface:**
This tool can be easily enabled with MLIR PassInstrumentation or [MLIR Actions](https://discourse.llvm.org/t/rfc-mlir-action-tracing-and-debugging-mlir-based-compilers/68679), to get the mutations after applying pass, pipeline or rewriter. Or additionally, this could be made part of the MLIRContext to extend the scope and the available information.

1. Create a `mlir::IRMutationManager` with static storage.
2. Reset the state of the `IRMutationManager` prior to running the pass, pipeline or rewriter.
```cpp
    mutation_manager.reset(/*IRUnit*/ op, /*pass_name*/ transform_tag);
```
3. Get the list of mutations after running the the pass, pipeline or rewriter, to print the list or supply to a DIFF Tool or Graph Visualizer.
```cpp
    auto mutations_list = mutationM=_manager.getMutations(op);
    for (auto &&it : mutations_list) {
      it->print();
    }
```
4. Perform a LocationSnapshot to reset/re-number the IR Source Locations, if there were mutations.
```cpp
    if (!mutations_list.empty()) {
      if (failed(generateLocationsFromIR(pass_name, op, OpPrintingFlags(), tag)))
        return signalPassFailure();
    }
```

This PR modifies the LocationSnapshot.cc to demonstrate the tool use. Run `-snapshot-op-locations` after every pass in the pipeline, like-

> ./tf-opt  -snapshot-op-locations -inline='default-pipeline=''' -snapshot-op-locations -tf-shape-inference -snapshot-op-locations  -tfl-prepare-tf -snapshot-op-locations  -tfl-legalize-tf -snapshot-op-locations -tfl-optimize -snapshot-op-locations input.mlir


**_Please note: LocationSnapshot is modified here only for demonstration purpose._**